### PR TITLE
npmx_charger: Update npm1300 discharge limit

### DIFF
--- a/adk/npm1300_peripherals.h
+++ b/adk/npm1300_peripherals.h
@@ -77,7 +77,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define NPM_BCHARGER_ADC_BITS_RESOLUTION         1023UL  ///< Bits resolution of 10-bit SAR ADC, from the product specification.
 #define NPM_BCHARGER_ADC_CALC_DISCHARGE_MUL      1000    ///< Multiplication value used do calculate discharge current from ADC value.
-#define NPM_BCHARGER_ADC_CALC_DISCHARGE_DIV      1196    ///< Divisor value used do calculate discharge current from ADC value.
+#define NPM_BCHARGER_ADC_CALC_DISCHARGE_DIV      893     ///< Divisor value used do calculate discharge current from ADC value.
 #define NPM_BCHARGER_ADC_CALC_CHARGE_MUL         1250    ///< Multiplication value used do calculate charge current from ADC value.
 #define NPM_BCHARGER_ADC_CALC_CHARGE_DIV         -1000   ///< Divisor value used do calculate charge current from ADC value.
 
@@ -86,11 +86,9 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define NPM_BCHARGER_CHARGING_CURRENT_STEP_MA    2UL     ///< Charging current step in milliamperes, from the product specification.
 #define NPM_BCHARGER_CHARGING_CURRENT_DEFAULT    32UL    ///< Default charging current in milliamperes.
 
-#define NPM_BCHARGER_DISCHARGING_CURRENT_MIN_MA  270UL   ///< Minimum possible discharging current in milliamperes, from the product specification.
-#define NPM_BCHARGER_DISCHARGING_CURRENT_MAX_MA  1340UL  ///< Maximum possible discharging current in milliamperes, from the product specification.
-#define NPM_BCHARGER_DISCHARGING_MULTIPLIER      100UL   ///< Magic number used to calculate discharging code as fixed point number.
-#define NPM_BCHARGER_DISCHARGING_CONST           323UL   ///< Magic number used to calculate discharging code.
-#define NPM_BCHARGER_DISCHARGING_CURRENT_DEFAULT 1340UL  ///< Default discharging current in milliamperes.
+#define NPM_BCHARGER_DISCHARGING_CURRENTS_MA     {200UL, 1000UL} ///< List of allowed discharging currents in milliamperes, from the product specification.
+#define NPM_BCHARGER_DISCHARGING_CURRENTS_CODE   {84UL, 415UL} ///< List of allowed discharging current codes in milliamperes, from the product specification.
+#define NPM_BCHARGER_DISCHARGING_CURRENT_DEFAULT 1000UL  ///< Default discharging current in milliamperes.
 
 #define NPM_BCHARGER_DIE_TEMPERATURE_CONST_1     3946700UL ///< Magic number from "Equation for die temperature limits" in the product specification.
 #define NPM_BCHARGER_DIE_TEMPERATURE_CONST_2     7926UL    ///< Magic number from "Equation for die temperature limits" in the product specification.

--- a/adk/npm1304_peripherals.h
+++ b/adk/npm1304_peripherals.h
@@ -86,9 +86,9 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define NPM_BCHARGER_CHARGING_CURRENT_STEP_MA    1UL     ///< Charging current step in milliamperes, from the product specification. Note: using 1 mA instead of 0.5 mA to avoid npmx API update
 #define NPM_BCHARGER_CHARGING_CURRENT_DEFAULT    4UL     ///< Default charging current in milliamperes.
 
-#define NPM_BCHARGER_DISCHARGING_CURRENT_MIN_MA  150UL   ///< Minimum possible discharging current in milliamperes, from the product specification.
-#define NPM_BCHARGER_DISCHARGING_CURRENT_MAX_MA  150UL   ///< Maximum possible discharging current in milliamperes, from the product specification.
-#define NPM_BCHARGER_DISCHARGING_CURRENT_DEFAULT 150UL   ///< Default discharging current in milliamperes.
+#define NPM_BCHARGER_DISCHARGING_CURRENTS_MA     {150UL} ///< List of allowed discharging currents in milliamperes, from the product specification.
+#define NPM_BCHARGER_DISCHARGING_CURRENTS_CODE   {415UL} ///< List of allowed discharging current codes in milliamperes, from the product specification.
+#define NPM_BCHARGER_DISCHARGING_CURRENT_DEFAULT 150UL  ///< Default discharging current in milliamperes.
 
 #define NPM_BCHARGER_DIE_TEMPERATURE_CONST_1     3946700UL ///< Magic number from "Equation for die temperature limits" in the product specification.
 #define NPM_BCHARGER_DIE_TEMPERATURE_CONST_2     7926UL    ///< Magic number from "Equation for die temperature limits" in the product specification.

--- a/drivers/include/npmx_charger.h
+++ b/drivers/include/npmx_charger.h
@@ -311,10 +311,10 @@ npmx_error_t npmx_charger_charging_current_set(npmx_charger_t * p_instance, uint
 npmx_error_t npmx_charger_charging_current_get(npmx_charger_t * p_instance, uint16_t * p_current);
 
 /**
- * @brief Function for setting maximum discharging current of nPM device. Default value after reset is 1000 mA.
+ * @brief Function for setting maximum discharging current of nPM device.
  *
  * @param[in] p_instance Pointer to the CHARGER instance.
- * @param[in] current    Maximum discharging current in milliamperes in a range from 270 to 1340 with a step of 2.
+ * @param[in] current    Maximum discharging current in milliamperes.
  *
  * @retval NPMX_SUCCESS             Operation performed successfully.
  * @retval NPMX_ERROR_INVALID_PARAM Current out of range.
@@ -323,11 +323,11 @@ npmx_error_t npmx_charger_charging_current_get(npmx_charger_t * p_instance, uint
 npmx_error_t npmx_charger_discharging_current_set(npmx_charger_t * p_instance, uint16_t current);
 
 /**
- * @brief Function for reading maximum discharging current of nPM device. Default value after reset is 1000 mA.
+ * @brief Function for reading maximum discharging current of nPM device.
  *
  * @param[in]  p_instance Pointer to the CHARGER instance.
  * @param[out] p_current  Pointer to the current variable.
- *                        Maximum discharging current in milliamperes from in a range from 270 to 1340 with a step of 2.
+ *                        Maximum discharging current in milliamperes from.
  *
  * @retval NPMX_SUCCESS  Operation performed successfully.
  * @retval NPMX_ERROR_IO Error using IO bus line.


### PR DESCRIPTION
Update battery discharge limit for nPM1300 to be aligned with datasheet. 130x_peripherals.h updated with a list of allowed values instead of a range.